### PR TITLE
Cisco nexus support

### DIFF
--- a/examples/cisco_nexus_dc/README.md
+++ b/examples/cisco_nexus_dc/README.md
@@ -1,0 +1,23 @@
+# Cisco Nexus EVPN VXLAN Data Centre Example
+
+This example project demonstrates how to use NITA to build and test an EVPN VXLAN leaf‑spine data centre using Cisco Nexus switches.
+
+The structure of this example mirrors the existing Juniper QFX example (`evpn_vxlan_erb_dc`) but is intended for Nexus platforms.  At a minimum it includes:
+
+- An Ansible playbook (`build/sites.yaml`) to build the network using roles designed for Cisco NX‑OS.
+- Inventory and variable files under `group_vars` and `host_vars`.
+- A `test` directory where Robot Framework tests can be added for validation.
+
+> **Note:** The Nexus‑specific Ansible roles referenced from `sites.yaml` are not yet implemented in this repository.  You should create or import appropriate roles for Nexus (for example `nxos_vxlan_common`, `nxos_vxlan_leaf`, `nxos_vxlan_spine`, etc.) before running the playbook.
+
+To use this example:
+
+1. Copy or create Cisco Nexus–specific roles under your Ansible roles path.
+2. Populate `host_vars` and `group_vars` with the IP addresses, credentials and other settings for your environment.
+3. Run the build playbook to push the initial configurations:
+   ```
+   ansible-playbook build/sites.yaml
+   ```
+4. Add Robot Framework test cases to the `test` directory and execute them using the `robot` command or via NITA's Jenkins integration.
+
+This skeleton is provided as a starting point for building and testing EVPN VXLAN fabrics on Cisco Nexus hardware.

--- a/examples/cisco_nexus_dc/build/sites.yaml
+++ b/examples/cisco_nexus_dc/build/sites.yaml
@@ -1,0 +1,28 @@
+# Cisco Nexus EVPN VXLAN build playbook
+
+---
+
+# This playbook is a placeholder for building a leaf‑spine EVPN VXLAN data centre using Cisco Nexus switches.
+# It mirrors the structure of the Juniper QFX example and references roles that should be created
+# for NX‑OS devices.
+
+- import_playbook: ../make_clean.yaml
+- import_playbook: ../make_hosts.yaml
+
+- hosts: spines
+  connection: local
+  roles:
+    - { role: nxos_vxlan_common }
+    - { role: nxos_vxlan_spine }
+
+- hosts: leaves
+  connection: local
+  roles:
+    - { role: nxos_vxlan_common }
+    - { role: nxos_vxlan_leaf }
+    - { role: nxos_vxlan_vni }
+    - { role: nxos_vxlan_port }
+    - { role: nxos_vxlan_vrf }
+    - { role: nxos_vxlan_policy }
+
+# Add additional host groups (such as border_leaves or firewalls) as needed and assign appropriate roles.


### PR DESCRIPTION
This pull request adds an initial framework for deploying and testing Cisco Nexus switches with NITA. It introduces a new example in `examples/cisco_nexus_dc` with a README outlining the project structure and a skeleton `build/sites.yaml` playbook referencing NX-OS roles. Additional roles and variables will need to be implemented for full functionality.